### PR TITLE
Make voxel computation consistent across all source code (#354)

### DIFF
--- a/cpp/kiss_icp/core/Preprocessing.cpp
+++ b/cpp/kiss_icp/core/Preprocessing.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 namespace {
+// TODO(all): Maybe try to merge these voxel uitls with VoxelHashMap implementation
 using Voxel = Eigen::Vector3i;
 struct VoxelHash {
     size_t operator()(const Voxel &voxel) const {
@@ -39,6 +40,12 @@ struct VoxelHash {
         return ((1 << 20) - 1) & (vec[0] * 73856093 ^ vec[1] * 19349669 ^ vec[2] * 83492791);
     }
 };
+
+Voxel PointToVoxel(const Eigen::Vector3d &point, double voxel_size) {
+    return Voxel(static_cast<int>(std::floor(point.x() / voxel_size)),
+                 static_cast<int>(std::floor(point.y() / voxel_size)),
+                 static_cast<int>(std::floor(point.z() / voxel_size)));
+}
 }  // namespace
 
 namespace kiss_icp {
@@ -47,7 +54,7 @@ std::vector<Eigen::Vector3d> VoxelDownsample(const std::vector<Eigen::Vector3d> 
     tsl::robin_map<Voxel, Eigen::Vector3d, VoxelHash> grid;
     grid.reserve(frame.size());
     for (const auto &point : frame) {
-        const auto voxel = Voxel((point / voxel_size).cast<int>());
+        const auto voxel = PointToVoxel(point, voxel_size);
         if (grid.contains(voxel)) continue;
         grid.insert({voxel, point});
     }

--- a/cpp/kiss_icp/core/VoxelHashMap.cpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.cpp
@@ -75,7 +75,7 @@ void VoxelHashMap::Update(const std::vector<Eigen::Vector3d> &points, const Soph
 
 void VoxelHashMap::AddPoints(const std::vector<Eigen::Vector3d> &points) {
     std::for_each(points.cbegin(), points.cend(), [&](const auto &point) {
-        auto voxel = Voxel((point / voxel_size_).template cast<int>());
+        auto voxel = PointToVoxel(point);
         auto search = map_.find(voxel);
         if (search != map_.end()) {
             auto &voxel_block = search.value();

--- a/cpp/kiss_icp/core/VoxelHashMap.hpp
+++ b/cpp/kiss_icp/core/VoxelHashMap.hpp
@@ -58,9 +58,9 @@ struct VoxelHashMap {
     inline void Clear() { map_.clear(); }
     inline bool Empty() const { return map_.empty(); }
     inline Voxel PointToVoxel(const Eigen::Vector3d &point) const {
-        return Voxel(static_cast<int>(point.x() / voxel_size_),
-                     static_cast<int>(point.y() / voxel_size_),
-                     static_cast<int>(point.z() / voxel_size_));
+        return Voxel(static_cast<int>(std::floor(point.x() / voxel_size_)),
+                     static_cast<int>(std::floor(point.y() / voxel_size_)),
+                     static_cast<int>(std::floor(point.z() / voxel_size_)));
     }
     void Update(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &origin);
     void Update(const std::vector<Eigen::Vector3d> &points, const Sophus::SE3d &pose);


### PR DESCRIPTION
* Make voxel computation consistent across all source code, also use std::floor to have explicit control over type casting

* Use available function for conversion

* Make it a one liner

* remove numeric from includes

* New proposal

* remove numeric from include

* shrink diff

* Consistency as always

---------